### PR TITLE
Add get_first_available_zivid_device function

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are two main categories of samples: **Camera** and **Applications**. The s
       - [**SurfaceMatchingFindModel**][SurfaceMatchingFindModel-url] - This example shows surface-based 3D matching on data taken with the Zivid camera. The model used for matching is created from a reference view of the object. That model is then searched for in a newly acquired 3D point cloud. This example comes with two existing object models: a Pringles can (190 g) and a plastic Coca-Cola bottle (0.5 l).
 
 - **Procedures**
-  - [*get_first_available_zivid_device**][get_first_available_zivid_device-url] - * This procedure returns the first Zivid device from the input tuple of devices. The input tuple 'Devices' is typically returned by info_framegrabber function as follows: 'info_framegrabber ('GenICamTL','device', Information, Devices)'
+  - [*get_first_available_zivid_device**][get_first_available_zivid_device-url] - This procedure returns the first Zivid device from the input tuple of devices. The input tuple 'Devices' is typically returned by info_framegrabber function as follows: 'info_framegrabber ('GenICamTL','device', Information, Devices)'
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are two main categories of samples: **Camera** and **Applications**. The s
       - [**SurfaceMatchingFindModel**][SurfaceMatchingFindModel-url] - This example shows surface-based 3D matching on data taken with the Zivid camera. The model used for matching is created from a reference view of the object. That model is then searched for in a newly acquired 3D point cloud. This example comes with two existing object models: a Pringles can (190 g) and a plastic Coca-Cola bottle (0.5 l).
 
 - **Procedures**
-  - [*get_first_available_zivid_device**][get_first_available_zivid_device-url] - This procedure returns the first Zivid device from the input tuple of Devices. The input tuple Devices is typically returned by info_framegrabber function as follows: info_framegrabber ('GenICamTL','device', Information, Devices)
+  - [*get_first_available_zivid_device**][get_first_available_zivid_device-url] - * This procedure returns the first Zivid device from the input tuple of devices. The input tuple 'Devices' is typically returned by info_framegrabber function as follows: 'info_framegrabber ('GenICamTL','device', Information, Devices)'
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ There are two main categories of samples: **Camera** and **Applications**. The s
       - [**SurfaceMatchingFindModelFromFile**][SurfaceMatchingFindModelFromFile-url] - This example shows surface-based 3D matching on data taken with the Zivid camera. The model used for matching is created from a reference view of the object. That model is then searched for in a newly acquired 3D point cloud. This example comes with two existing object models: a Pringles can (190 g) and a plastic Coca-Cola bottle (0.5 l).
       - [**SurfaceMatchingFindModel**][SurfaceMatchingFindModel-url] - This example shows surface-based 3D matching on data taken with the Zivid camera. The model used for matching is created from a reference view of the object. That model is then searched for in a newly acquired 3D point cloud. This example comes with two existing object models: a Pringles can (190 g) and a plastic Coca-Cola bottle (0.5 l).
 
+- **Procedures**
+  - [*get_first_available_zivid_device**][get_first_available_zivid_device-url] - This procedure returns the first Zivid device from the input tuple of Devices. The input tuple Devices is typically returned by info_framegrabber function as follows: info_framegrabber ('GenICamTL','device', Information, Devices)
+
 ## Instructions
 
 1. [**Install Zivid Software**](https://www.zivid.com/downloads).
@@ -60,3 +63,4 @@ Zivid Samples are distributed under the [BSD license](https://github.com/zivid/h
 [SurfaceMatchingCreateModel-url]: source/Applications/Advanced/ObjectMatching/SurfaceMatchingCreateModel.hdev
 [SurfaceMatchingFindModelFromFile-url]: source/Applications/Advanced/ObjectMatching/SurfaceMatchingFindModelFromFile.hdev
 [SurfaceMatchingFindModel-url]: source/Applications/Advanced/ObjectMatching/SurfaceMatchingFindModel.hdev
+[get_first_available_zivid_device-url] source/Procedures/get_first_available_zivid_device.hdvp

--- a/source/Applications/Advanced/ObjectMatching/SurfaceMatchingCreateModel.hdev
+++ b/source/Applications/Advanced/ObjectMatching/SurfaceMatchingCreateModel.hdev
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hdevelop file_version="1.2" halcon_version="18.11.0.1">
+<hdevelop file_version="1.2" halcon_version="19.05.0.0">
 <procedure name="main">
 <interface/>
 <body>
@@ -18,6 +18,11 @@
 <c>* correctly set the environment variables. After this, you can</c>
 <c>* access the camera with the HALCON GenICamTL interface.</c>
 <c>* </c>
+<c></c>
+<c>*Get first available Zivid device</c>
+<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>import './../../../Procedures'</l>
+<l>get_first_available_zivid_device (ValueList, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>

--- a/source/Applications/Advanced/ObjectMatching/SurfaceMatchingCreateModel.hdev
+++ b/source/Applications/Advanced/ObjectMatching/SurfaceMatchingCreateModel.hdev
@@ -20,9 +20,9 @@
 <c>* </c>
 <c></c>
 <c>*Get first available Zivid device</c>
-<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>info_framegrabber ('GenICamTL','device', Information, Devices)</l>
 <l>import './../../../Procedures'</l>
-<l>get_first_available_zivid_device (ValueList, Device)</l>
+<l>get_first_available_zivid_device (Devices, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>

--- a/source/Applications/Advanced/ObjectMatching/SurfaceMatchingFindModel.hdev
+++ b/source/Applications/Advanced/ObjectMatching/SurfaceMatchingFindModel.hdev
@@ -30,9 +30,9 @@
 <l>Filename := ''</l>
 <c></c>
 <c>*Get first available Zivid device</c>
-<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>info_framegrabber ('GenICamTL','device', Information, Devices)</l>
 <l>import './../../../Procedures'</l>
-<l>get_first_available_zivid_device (ValueList, Device)</l>
+<l>get_first_available_zivid_device (Devices, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>

--- a/source/Applications/Advanced/ObjectMatching/SurfaceMatchingFindModel.hdev
+++ b/source/Applications/Advanced/ObjectMatching/SurfaceMatchingFindModel.hdev
@@ -29,6 +29,11 @@
 <c>* Your own model created with the SurfaceMatchingCreateModel.hdev</c>
 <l>Filename := ''</l>
 <c></c>
+<c>*Get first available Zivid device</c>
+<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>import './../../../Procedures'</l>
+<l>get_first_available_zivid_device (ValueList, Device)</l>
+<c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>
 <c></c>

--- a/source/Camera/Basic/Capture.hdev
+++ b/source/Camera/Basic/Capture.hdev
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hdevelop file_version="1.2" halcon_version="18.11.0.1">
+<hdevelop file_version="1.2" halcon_version="19.05.0.0">
 <procedure name="main">
 <interface/>
 <body>
@@ -22,8 +22,12 @@
 <l>dev_open_window (0, 0, WinWidth, WinHeight, 'blue', Window3D)</l>
 <l>dev_open_window (0, WinWidth, WinWidth, WinHeight, 'black', Window2D)</l>
 <c></c>
+<c>*Get first available Zivid device</c>
+<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>get_first_available_zivid_device (ValueList, Device)</l>
+<c></c>
 <c>* Connecting to the Zivid camera</c>
-<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>
+<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>
 <c></c>
 <c>* Configuring 3D-settings</c>
 <l>set_framegrabber_param (AcqHandle, 'create_objectmodel3d', 'enable')</l>
@@ -73,6 +77,32 @@
 </body>
 <docu id="main">
 <parameters/>
+</docu>
+</procedure>
+<procedure name="get_first_available_zivid_device">
+<interface>
+<ic>
+<par name="ValueList" base_type="ctrl" dimension="0"/>
+</ic>
+<oc>
+<par name="Device" base_type="ctrl" dimension="0"/>
+</oc>
+</interface>
+<body>
+<l>for i := 0 to |ValueList| by 1</l>
+<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
+<l>    if(SplitValues[2]{0:4} == 'Zivid')</l>
+<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
+<l>        break</l>
+<l>    endif</l>
+<l>endfor</l>
+<l>return ()</l>
+</body>
+<docu id="get_first_available_zivid_device">
+<parameters>
+<parameter id="Device"/>
+<parameter id="ValueList"/>
+</parameters>
 </docu>
 </procedure>
 </hdevelop>

--- a/source/Camera/Basic/Capture.hdev
+++ b/source/Camera/Basic/Capture.hdev
@@ -23,9 +23,9 @@
 <l>dev_open_window (0, WinWidth, WinWidth, WinHeight, 'black', Window2D)</l>
 <c></c>
 <c>*Get first available Zivid device</c>
-<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>info_framegrabber ('GenICamTL','device', Information, Devices)</l>
 <l>import './../../Procedures'</l>
-<l>get_first_available_zivid_device (ValueList, Device)</l>
+<l>get_first_available_zivid_device (Devices, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>

--- a/source/Camera/Basic/Capture.hdev
+++ b/source/Camera/Basic/Capture.hdev
@@ -24,6 +24,7 @@
 <c></c>
 <c>*Get first available Zivid device</c>
 <l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>import './../../Procedures'</l>
 <l>get_first_available_zivid_device (ValueList, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
@@ -77,32 +78,6 @@
 </body>
 <docu id="main">
 <parameters/>
-</docu>
-</procedure>
-<procedure name="get_first_available_zivid_device">
-<interface>
-<ic>
-<par name="ValueList" base_type="ctrl" dimension="0"/>
-</ic>
-<oc>
-<par name="Device" base_type="ctrl" dimension="0"/>
-</oc>
-</interface>
-<body>
-<l>for i := 0 to |ValueList| by 1</l>
-<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
-<l>    if(SplitValues[2]{0:4} == 'Zivid')</l>
-<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
-<l>        break</l>
-<l>    endif</l>
-<l>endfor</l>
-<l>return ()</l>
-</body>
-<docu id="get_first_available_zivid_device">
-<parameters>
-<parameter id="Device"/>
-<parameter id="ValueList"/>
-</parameters>
 </docu>
 </procedure>
 </hdevelop>

--- a/source/Camera/Basic/CaptureHDR.hdev
+++ b/source/Camera/Basic/CaptureHDR.hdev
@@ -24,6 +24,7 @@
 <c></c>
 <c>*Get first available Zivid device</c>
 <l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>import './../../Procedures'</l>
 <l>get_first_available_zivid_device (ValueList, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
@@ -83,32 +84,6 @@
 </body>
 <docu id="main">
 <parameters/>
-</docu>
-</procedure>
-<procedure name="get_first_available_zivid_device">
-<interface>
-<ic>
-<par name="ValueList" base_type="ctrl" dimension="0"/>
-</ic>
-<oc>
-<par name="Device" base_type="ctrl" dimension="0"/>
-</oc>
-</interface>
-<body>
-<l>for i := 0 to |ValueList| by 1</l>
-<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
-<l>    if (SplitValues[2]{0:4} == 'Zivid')</l>
-<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
-<l>        break</l>
-<l>    endif</l>
-<l>endfor</l>
-<l>return ()</l>
-</body>
-<docu id="get_first_available_zivid_device">
-<parameters>
-<parameter id="Device"/>
-<parameter id="ValueList"/>
-</parameters>
 </docu>
 </procedure>
 </hdevelop>

--- a/source/Camera/Basic/CaptureHDR.hdev
+++ b/source/Camera/Basic/CaptureHDR.hdev
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hdevelop file_version="1.2" halcon_version="18.11.0.1">
+<hdevelop file_version="1.2" halcon_version="19.05.0.0">
 <procedure name="main">
 <interface/>
 <body>
@@ -22,8 +22,12 @@
 <l>dev_open_window (0, 0, WinWidth, WinHeight, 'blue', Window3D)</l>
 <l>dev_open_window (0, WinWidth, WinWidth, WinHeight, 'black', Window2D)</l>
 <c></c>
+<c>*Get first available Zivid device</c>
+<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>get_first_available_zivid_device (ValueList, Device)</l>
+<c></c>
 <c>* Connecting to the Zivid camera</c>
-<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>
+<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>
 <c></c>
 <c>* Configuring 3D-settings</c>
 <l>set_framegrabber_param (AcqHandle, 'create_objectmodel3d', 'enable')</l>
@@ -79,6 +83,32 @@
 </body>
 <docu id="main">
 <parameters/>
+</docu>
+</procedure>
+<procedure name="get_first_available_zivid_device">
+<interface>
+<ic>
+<par name="ValueList" base_type="ctrl" dimension="0"/>
+</ic>
+<oc>
+<par name="Device" base_type="ctrl" dimension="0"/>
+</oc>
+</interface>
+<body>
+<l>for i := 0 to |ValueList| by 1</l>
+<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
+<l>    if (SplitValues[2]{0:4} == 'Zivid')</l>
+<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
+<l>        break</l>
+<l>    endif</l>
+<l>endfor</l>
+<l>return ()</l>
+</body>
+<docu id="get_first_available_zivid_device">
+<parameters>
+<parameter id="Device"/>
+<parameter id="ValueList"/>
+</parameters>
 </docu>
 </procedure>
 </hdevelop>

--- a/source/Camera/Basic/CaptureHDR.hdev
+++ b/source/Camera/Basic/CaptureHDR.hdev
@@ -23,9 +23,9 @@
 <l>dev_open_window (0, WinWidth, WinWidth, WinHeight, 'black', Window2D)</l>
 <c></c>
 <c>*Get first available Zivid device</c>
-<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>info_framegrabber ('GenICamTL','device', Information, Devices)</l>
 <l>import './../../Procedures'</l>
-<l>get_first_available_zivid_device (ValueList, Device)</l>
+<l>get_first_available_zivid_device (Devices, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>

--- a/source/Camera/Basic/CaptureHDRCompleteSettings.hdev
+++ b/source/Camera/Basic/CaptureHDRCompleteSettings.hdev
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hdevelop file_version="1.2" halcon_version="18.11.0.1">
+<hdevelop file_version="1.2" halcon_version="19.05.0.0">
 <procedure name="main">
 <interface/>
 <body>
@@ -23,8 +23,12 @@
 <l>WinHeight := 800</l>
 <l>dev_open_window (0, 0, WinWidth, WinHeight, 'blue', Window3D)</l>
 <c></c>
+<c>*Get first available Zivid device</c>
+<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>get_first_available_zivid_device (ValueList, Device)</l>
+<c></c>
 <c>* Connecting to the Zivid camera</c>
-<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>
+<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>
 <c></c>
 <c>* Configuring 3D-settings</c>
 <l>set_framegrabber_param (AcqHandle, 'create_objectmodel3d', 'enable')</l>
@@ -128,6 +132,32 @@
 </body>
 <docu id="main">
 <parameters/>
+</docu>
+</procedure>
+<procedure name="get_first_available_zivid_device">
+<interface>
+<ic>
+<par name="ValueList" base_type="ctrl" dimension="0"/>
+</ic>
+<oc>
+<par name="Device" base_type="ctrl" dimension="0"/>
+</oc>
+</interface>
+<body>
+<l>for i := 0 to |ValueList| by 1</l>
+<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
+<l>    if (SplitValues[2]{0:4} == 'Zivid')</l>
+<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
+<l>        break</l>
+<l>    endif</l>
+<l>endfor</l>
+<l>return ()</l>
+</body>
+<docu id="get_first_available_zivid_device">
+<parameters>
+<parameter id="Device"/>
+<parameter id="ValueList"/>
+</parameters>
 </docu>
 </procedure>
 </hdevelop>

--- a/source/Camera/Basic/CaptureHDRCompleteSettings.hdev
+++ b/source/Camera/Basic/CaptureHDRCompleteSettings.hdev
@@ -25,6 +25,7 @@
 <c></c>
 <c>*Get first available Zivid device</c>
 <l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>import './../../Procedures'</l>
 <l>get_first_available_zivid_device (ValueList, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
@@ -132,32 +133,6 @@
 </body>
 <docu id="main">
 <parameters/>
-</docu>
-</procedure>
-<procedure name="get_first_available_zivid_device">
-<interface>
-<ic>
-<par name="ValueList" base_type="ctrl" dimension="0"/>
-</ic>
-<oc>
-<par name="Device" base_type="ctrl" dimension="0"/>
-</oc>
-</interface>
-<body>
-<l>for i := 0 to |ValueList| by 1</l>
-<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
-<l>    if (SplitValues[2]{0:4} == 'Zivid')</l>
-<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
-<l>        break</l>
-<l>    endif</l>
-<l>endfor</l>
-<l>return ()</l>
-</body>
-<docu id="get_first_available_zivid_device">
-<parameters>
-<parameter id="Device"/>
-<parameter id="ValueList"/>
-</parameters>
 </docu>
 </procedure>
 </hdevelop>

--- a/source/Camera/Basic/CaptureHDRCompleteSettings.hdev
+++ b/source/Camera/Basic/CaptureHDRCompleteSettings.hdev
@@ -24,9 +24,9 @@
 <l>dev_open_window (0, 0, WinWidth, WinHeight, 'blue', Window3D)</l>
 <c></c>
 <c>*Get first available Zivid device</c>
-<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>info_framegrabber ('GenICamTL','device', Information, Devices)</l>
 <l>import './../../Procedures'</l>
-<l>get_first_available_zivid_device (ValueList, Device)</l>
+<l>get_first_available_zivid_device (Devices, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>

--- a/source/Camera/Basic/CaptureHDRLoop.hdev
+++ b/source/Camera/Basic/CaptureHDRLoop.hdev
@@ -23,9 +23,9 @@
 <l>dev_open_window (0, 0, WinWidth, WinHeight, 'blue', Window3D)</l>
 <c></c>
 <c>*Get first available Zivid device</c>
-<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>info_framegrabber ('GenICamTL','device', Information, Devices)</l>
 <l>import './../../Procedures'</l>
-<l>get_first_available_zivid_device (ValueList, Device)</l>
+<l>get_first_available_zivid_device (Devices, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>

--- a/source/Camera/Basic/CaptureHDRLoop.hdev
+++ b/source/Camera/Basic/CaptureHDRLoop.hdev
@@ -22,8 +22,12 @@
 <l>WinHeight := 800</l>
 <l>dev_open_window (0, 0, WinWidth, WinHeight, 'blue', Window3D)</l>
 <c></c>
+<c>*Get first available Zivid device</c>
+<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>get_first_available_zivid_device (ValueList, Device)</l>
+<c></c>
 <c>* Connecting to the Zivid camera</c>
-<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>
+<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>
 <c></c>
 <c>* Configuring 3D-settings</c>
 <l>set_framegrabber_param (AcqHandle, 'create_objectmodel3d', 'enable')</l>
@@ -138,6 +142,32 @@
 <parameters>
 <parameter id="AcqHandle"/>
 <parameter id="path"/>
+</parameters>
+</docu>
+</procedure>
+<procedure name="get_first_available_zivid_device">
+<interface>
+<ic>
+<par name="ValueList" base_type="ctrl" dimension="0"/>
+</ic>
+<oc>
+<par name="Device" base_type="ctrl" dimension="0"/>
+</oc>
+</interface>
+<body>
+<l>for i := 0 to |ValueList| by 1</l>
+<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
+<l>    if (SplitValues[2]{0:4} == 'Zivid')</l>
+<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
+<l>        break</l>
+<l>    endif</l>
+<l>endfor</l>
+<l>return ()</l>
+</body>
+<docu id="get_first_available_zivid_device">
+<parameters>
+<parameter id="Device"/>
+<parameter id="ValueList"/>
 </parameters>
 </docu>
 </procedure>

--- a/source/Camera/Basic/CaptureHDRLoop.hdev
+++ b/source/Camera/Basic/CaptureHDRLoop.hdev
@@ -24,6 +24,7 @@
 <c></c>
 <c>*Get first available Zivid device</c>
 <l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>import './../../Procedures'</l>
 <l>get_first_available_zivid_device (ValueList, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
@@ -142,32 +143,6 @@
 <parameters>
 <parameter id="AcqHandle"/>
 <parameter id="path"/>
-</parameters>
-</docu>
-</procedure>
-<procedure name="get_first_available_zivid_device">
-<interface>
-<ic>
-<par name="ValueList" base_type="ctrl" dimension="0"/>
-</ic>
-<oc>
-<par name="Device" base_type="ctrl" dimension="0"/>
-</oc>
-</interface>
-<body>
-<l>for i := 0 to |ValueList| by 1</l>
-<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
-<l>    if (SplitValues[2]{0:4} == 'Zivid')</l>
-<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
-<l>        break</l>
-<l>    endif</l>
-<l>endfor</l>
-<l>return ()</l>
-</body>
-<docu id="get_first_available_zivid_device">
-<parameters>
-<parameter id="Device"/>
-<parameter id="ValueList"/>
 </parameters>
 </docu>
 </procedure>

--- a/source/Camera/Basic/CaptureSavePLY.hdev
+++ b/source/Camera/Basic/CaptureSavePLY.hdev
@@ -21,8 +21,12 @@
 <l>dev_open_window (0, 0, WinWidth, WinHeight, 'blue', Window3D)</l>
 <l>dev_open_window (0, WinWidth, WinWidth, WinHeight, 'black', Window2D)</l>
 <c></c>
+<c>*Get first available Zivid device</c>
+<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>get_first_available_zivid_device (ValueList, Device)</l>
+<c></c>
 <c>* Connecting to the Zivid camera</c>
-<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', 'default', 0, 0, AcqHandle)</l>
+<l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>
 <c></c>
 <c>* Configuring 3D-settings</c>
 <l>set_framegrabber_param (AcqHandle, 'create_objectmodel3d', 'enable')</l>
@@ -81,6 +85,32 @@
 </body>
 <docu id="main">
 <parameters/>
+</docu>
+</procedure>
+<procedure name="get_first_available_zivid_device">
+<interface>
+<ic>
+<par name="ValueList" base_type="ctrl" dimension="0"/>
+</ic>
+<oc>
+<par name="Device" base_type="ctrl" dimension="0"/>
+</oc>
+</interface>
+<body>
+<l>for i := 0 to |ValueList| by 1</l>
+<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
+<l>    if (SplitValues[2]{0:4} == 'Zivid')</l>
+<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
+<l>        break</l>
+<l>    endif</l>
+<l>endfor</l>
+<l>return ()</l>
+</body>
+<docu id="get_first_available_zivid_device">
+<parameters>
+<parameter id="Device"/>
+<parameter id="ValueList"/>
+</parameters>
 </docu>
 </procedure>
 </hdevelop>

--- a/source/Camera/Basic/CaptureSavePLY.hdev
+++ b/source/Camera/Basic/CaptureSavePLY.hdev
@@ -22,9 +22,9 @@
 <l>dev_open_window (0, WinWidth, WinWidth, WinHeight, 'black', Window2D)</l>
 <c></c>
 <c>*Get first available Zivid device</c>
-<l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>info_framegrabber ('GenICamTL','device', Information, Devices)</l>
 <l>import './../../Procedures'</l>
-<l>get_first_available_zivid_device (ValueList, Device)</l>
+<l>get_first_available_zivid_device (Devices, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
 <l>open_framegrabber ('GenICamTL',1, 1, 0, 0, 0, 0, 'progressive', -1, 'default', -1, 'false', 'default', Device, 0, 0, AcqHandle)</l>

--- a/source/Camera/Basic/CaptureSavePLY.hdev
+++ b/source/Camera/Basic/CaptureSavePLY.hdev
@@ -23,6 +23,7 @@
 <c></c>
 <c>*Get first available Zivid device</c>
 <l>info_framegrabber ('GenICamTL','info_boards', Information, ValueList)</l>
+<l>import './../../Procedures'</l>
 <l>get_first_available_zivid_device (ValueList, Device)</l>
 <c></c>
 <c>* Connecting to the Zivid camera</c>
@@ -85,32 +86,6 @@
 </body>
 <docu id="main">
 <parameters/>
-</docu>
-</procedure>
-<procedure name="get_first_available_zivid_device">
-<interface>
-<ic>
-<par name="ValueList" base_type="ctrl" dimension="0"/>
-</ic>
-<oc>
-<par name="Device" base_type="ctrl" dimension="0"/>
-</oc>
-</interface>
-<body>
-<l>for i := 0 to |ValueList| by 1</l>
-<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
-<l>    if (SplitValues[2]{0:4} == 'Zivid')</l>
-<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
-<l>        break</l>
-<l>    endif</l>
-<l>endfor</l>
-<l>return ()</l>
-</body>
-<docu id="get_first_available_zivid_device">
-<parameters>
-<parameter id="Device"/>
-<parameter id="ValueList"/>
-</parameters>
 </docu>
 </procedure>
 </hdevelop>

--- a/source/Procedures/get_first_available_zivid_device.hdvp
+++ b/source/Procedures/get_first_available_zivid_device.hdvp
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hdevelop file_version="1.2" halcon_version="19.05.0.0">
+<procedure name="get_first_available_zivid_device">
+<interface>
+<ic>
+<par name="ValueList" base_type="ctrl" dimension="0"/>
+</ic>
+<oc>
+<par name="Device" base_type="ctrl" dimension="0"/>
+</oc>
+</interface>
+<body>
+<l>for i := 0 to |ValueList| by 1</l>
+<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
+<l>    if(SplitValues[2]{0:4} == 'Zivid')</l>
+<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
+<l>        break</l>
+<l>    endif</l>
+<l>endfor</l>
+<l>return ()</l>
+</body>
+<docu id="get_first_available_zivid_device">
+<parameters>
+<parameter id="Device"/>
+<parameter id="ValueList"/>
+</parameters>
+</docu>
+</procedure>
+</hdevelop>

--- a/source/Procedures/get_first_available_zivid_device.hdvp
+++ b/source/Procedures/get_first_available_zivid_device.hdvp
@@ -3,17 +3,22 @@
 <procedure name="get_first_available_zivid_device">
 <interface>
 <ic>
-<par name="ValueList" base_type="ctrl" dimension="0"/>
+<par name="Devices" base_type="ctrl" dimension="0"/>
 </ic>
 <oc>
 <par name="Device" base_type="ctrl" dimension="0"/>
 </oc>
 </interface>
 <body>
-<l>for i := 0 to |ValueList| by 1</l>
-<l>    SplitValues := split(split(ValueList[i], '|'), ':')</l>
-<l>    if(SplitValues[2]{0:4} == 'Zivid')</l>
-<l>        Device := SplitValues[2]{0:strlen(SplitValues[2])-2}</l>
+<c>* This procedure returns the first Zivid device from the input</c>
+<c>* tuple of Devices. The input tuple Devices is typically returned</c>
+<c>* by info_framegrabber function as follows:</c>
+<c>* 'info_framegrabber ('GenICamTL','device', Information, Devices)'</c>
+<c></c>
+<l>for i := 0 to |Devices| by 1</l>
+<l>    SplitDevices := split(split(Devices[i], '|'), ':')</l>
+<l>    if(SplitDevices[2]{0:4} == 'Zivid')</l>
+<l>        Device := SplitDevices[2]{0:strlen(SplitDevices[2])-2}</l>
 <l>        break</l>
 <l>    endif</l>
 <l>endfor</l>
@@ -22,7 +27,7 @@
 <docu id="get_first_available_zivid_device">
 <parameters>
 <parameter id="Device"/>
-<parameter id="ValueList"/>
+<parameter id="Devices"/>
 </parameters>
 </docu>
 </procedure>

--- a/source/Procedures/get_first_available_zivid_device.hdvp
+++ b/source/Procedures/get_first_available_zivid_device.hdvp
@@ -11,7 +11,7 @@
 </interface>
 <body>
 <c>* This procedure returns the first Zivid device from the input</c>
-<c>* tuple of Devices. The input tuple Devices is typically returned</c>
+<c>* tuple 'Devices'. The input tuple 'Devices' is typically returned</c>
 <c>* by info_framegrabber function as follows:</c>
 <c>* 'info_framegrabber ('GenICamTL','device', Information, Devices)'</c>
 <c></c>

--- a/source/Procedures/get_first_available_zivid_device.hdvp
+++ b/source/Procedures/get_first_available_zivid_device.hdvp
@@ -11,7 +11,7 @@
 </interface>
 <body>
 <c>* This procedure returns the first Zivid device from the input</c>
-<c>* tuple 'Devices'. The input tuple 'Devices' is typically returned</c>
+<c>* tuple of devices. The input tuple 'Devices' is typically returned</c>
 <c>* by info_framegrabber function as follows:</c>
 <c>* 'info_framegrabber ('GenICamTL','device', Information, Devices)'</c>
 <c></c>


### PR DESCRIPTION
This function prevents open_framegrabber from connecting to the TeliCamTL64 producer of the internal 2D camera. Without this function, Halcon connects to the first suitable device it finds in the GENICAM_GENTL_64_PATH. With this new function, the order in the path becomes irrelevant.